### PR TITLE
qcom: Drop qti extension from powerhal service

### DIFF
--- a/qcom/vendor/file_contexts
+++ b/qcom/vendor/file_contexts
@@ -2,4 +2,4 @@
 /(vendor|system/vendor)/bin/hw/vendor\.qti\.hardware\.cryptfshw@1\.0-service-qti\.qsee   u:object_r:hal_keymaster_qti_exec:s0
 
 # Power
-/(vendor|system/vendor)/bin/hw/android\.hardware\.power-service-qti               u:object_r:hal_power_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.hardware\.power-service               u:object_r:hal_power_default_exec:s0


### PR DESCRIPTION
 * We don't append '-qti' to the powerhal service